### PR TITLE
Remove default service account name

### DIFF
--- a/prometheus/before-13/amp_ingest_override_values.yml
+++ b/prometheus/before-13/amp_ingest_override_values.yml
@@ -2,9 +2,6 @@
 ## For the rest of prometheus helm chart values see: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml
 ##
 serviceAccounts:
-  server:
-    name: amp-iamproxy-ingest-service-account
-
   ## Disable alert manager roles
   ##
   alertmanager:

--- a/prometheus/latest/amp_ingest_override_values.yml
+++ b/prometheus/latest/amp_ingest_override_values.yml
@@ -2,9 +2,6 @@
 ## For the rest of prometheus helm chart values see: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml
 ##
 serviceAccounts:
-  server:
-    name: amp-iamproxy-ingest-service-account
-
   ## Disable alert manager roles
   ##
   alertmanager:


### PR DESCRIPTION
Users can have service account already created and service account name could be different from `amp-iamproxy-ingest-service-account`. 
We should not force service account name in the default configuration.
