### PR TITLE
update file for prometheus helm chart 13.8.0

### DIFF
--- a/prometheus/latest/amp_ingest_override_values.yml
+++ b/prometheus/latest/amp_ingest_override_values.yml
@@ -13,15 +13,6 @@ serviceAccounts:
     create: false
 
 server:
-  ## Add sigv4 container to prometheus server
-  ##
-  sidecarContainers:
-    aws-sigv4-proxy-sidecar:
-      image: public.ecr.aws/aws-observability/aws-sigv4-proxy:1.0
-      ports:
-       - name: aws-sigv4-proxy
-         containerPort: 8005
-
   ## Use a statefulset instead of a deployment for resiliency
   ##
   statefulSet:


### PR DESCRIPTION
the official prom helmchart ships with prometheus 2.26.0 since 13.8.0, so we don't need the sidecar anymore and can use prometheus sigv4 signing instead.